### PR TITLE
Load BlueZ4 discovery module.

### DIFF
--- a/sparse/etc/pulse/arm_qualcomm_msm_8974_hammerhead_flattened_device_tree_000b.pa
+++ b/sparse/etc/pulse/arm_qualcomm_msm_8974_hammerhead_flattened_device_tree_000b.pa
@@ -42,7 +42,7 @@ load-module module-droid-card rate=48000 mute_routing_before=24576 mute_routing_
 
 load-module module-null-sink sink_name=sink.fake.sco rate=8000 channels=1
 load-module module-null-source source_name=source.fake.sco rate=8000 channels=1
-load-module module-bluetooth-discover sco_sink=sink.fake.sco sco_source=source.fake.sco
+load-module module-bluez4-discover sco_sink=sink.fake.sco sco_source=source.fake.sco
 
 load-module module-meego-mainvolume virtual_stream=true
 


### PR DESCRIPTION
Trying to load module-bluetooth-discover with bluez4 discover module
arguments causes bluez5-discover module loading to fail, which causes
whole module loading to fail. Until module-bluetooth-discover is fixed
to pass only bluez-specific arguments to the discovery modules, just
load module-bluez4-discover directly.
